### PR TITLE
Removed -j10 parameter that was used when building buildroot.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ bootstrap:
 	cp $(dir_configs)/buildroot $(dir_buildroot)/.config
 
 build:
-	make -j10 -C $(dir_buildroot)
+	make -C $(dir_buildroot)
 	cp $(dir_buildroot)/output/images/stm32f746-disco.dtb ${dir_publish}/
 	cp $(dir_buildroot)/output/images/zImage ${dir_publish}/
 


### PR DESCRIPTION
This is discouraged by buildroot manual page.
https://buildroot.org/downloads/manual/manual.html says:
'You should never use make -jN with Buildroot: top-level parallel make is currently not supported.
Instead, use the BR2_JLEVEL option to tell Buildroot to run the compilation of each individual
package with make -jN'